### PR TITLE
Publish deegree webservices 3.5.15 bugfix version

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -45,7 +45,7 @@ jobs:
           context: ./3.5
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: deegree/deegree3-docker:3.5.14,deegree/deegree3-docker:3.5,deegree/deegree3-docker:latest
+          tags: deegree/deegree3-docker:3.5.15,deegree/deegree3-docker:3.5,deegree/deegree3-docker:latest
   build-3_6:
     runs-on: ubuntu-latest
     steps:

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="deegree TMC <tmc@deegree.org>" \
   org.opencontainers.image.revision=$VCS_REF
 
 # set deegree version
-ARG DEEGREE_VERSION=3.5.14
+ARG DEEGREE_VERSION=3.5.15
 ENV DEEGREE_WORKSPACE_ROOT=/root/.deegree
 ENV CATALINA_OPTS="-Djavax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactoryImpl -Dlog.dir=$CATALINA_HOME/logs"
 ENV LANG=en_US.UTF-8

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Supported tags and respective `Dockerfile` links
 
 - deegree 3.6 (JDK 17/Tomcat 10.1): `3.6.0`, `3.6` - [Dockerfile](https://github.com/deegree/deegree3-docker/blob/main/3.6/Dockerfile)
-- deegree 3.5 (JDK 11/Tomcat 9): `3.5.14`, `3.5`, `latest` (deprecated tags: `3.5.13`, `3.5.12`, `3.5.11`, `3.5.10`, `3.5.8`, `3.5.7`, `3.5.6`, `3.5.5`, `3.5.4`, `3.5.3`, `3.5.2`, `3.5.1`, `3.5.0`) - [Dockerfile](https://github.com/deegree/deegree3-docker/blob/main/3.5/Dockerfile)
+- deegree 3.5 (JDK 11/Tomcat 9): `3.5.15`, `3.5`, `latest` (deprecated tags: `3.5.14`, `3.5.13`, `3.5.12`, `3.5.11`, `3.5.10`, `3.5.8`, `3.5.7`, `3.5.6`, `3.5.5`, `3.5.4`, `3.5.3`, `3.5.2`, `3.5.1`, `3.5.0`) - [Dockerfile](https://github.com/deegree/deegree3-docker/blob/main/3.5/Dockerfile)
 - deegree 3.4 (JDK 8/Tomcat 8.5): `v3.4.35`, `v3.4`, `3.4` (deprecated tags: `v3.4.34`, `v3.4.33`, `v3.4.32`, `v3.4.31`, `v3.4.29`, `v3.4.28`, `v3.4.26`, `v3.4.25`, `v3.4.24`, `v3.4.23`, `v3.4.22`, `v3.4.20`, `v3.4.19`, `v3.4.18`, `v3.4.17`, `v3.4.16`, `v3.4.15`, `v3.4.14`, `v3.4.13`, `v3.4.12`, `v3.4.10`, `v3.4.9`, `v3.4.8`, `v3.4.7`, `v3.4.6`, `v3.4.5`, `v3.4.4`, `v3.4.3`, `v3.4.2`, `v3.4.1`, `v3.4.0`) - [Dockerfile](https://github.com/deegree/deegree3-docker/blob/main/3.4/Dockerfile)
 
 # Quick reference


### PR DESCRIPTION
This PR updates the latest deegree-webservices Docker Image to bugfix version 3.5.15.