### PR TITLE
Publish deegree webservices 3.6-RC2 release candidate version

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="deegree TMC <tmc@deegree.org>" \
   org.opencontainers.image.revision=$VCS_REF
 
 # set deegree version
-ARG DEEGREE_VERSION=3.6-RC1
+ARG DEEGREE_VERSION=3.6-RC2
 
 # API key to use; if empty will not change API key
 ENV DEEGREE_API_KEY=


### PR DESCRIPTION
This PR updates the latest deegree-webservices Docker Image to release candidate version 3.6-RC2.