### PR TITLE
Publish 3.6.7 bugfix version

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -63,7 +63,7 @@ jobs:
           context: ./3.6
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: deegree/deegree3-docker:3.6.6,deegree/deegree3-docker:3.6,deegree/deegree3-docker:latest
+          tags: deegree/deegree3-docker:3.6.7,deegree/deegree3-docker:3.6,deegree/deegree3-docker:latest
           build-args: |
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VCS_REF=${{ github.sha }}

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -11,7 +11,7 @@ LABEL maintainer="deegree TMC <tmc@deegree.org>" \
   org.opencontainers.image.revision=$VCS_REF
 
 # set deegree version
-ARG DEEGREE_VERSION=3.6.6
+ARG DEEGREE_VERSION=3.6.7
 
 # API key to use; if empty will not change API key
 ENV DEEGREE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Supported tags and respective `Dockerfile` links
 
-- deegree 3.6 (JDK 17/Tomcat 10.1): `3.6.6`, `3.6`, `latest` (deprecated tags: `3.6.54`, `3.6.4`, `3.6.3`, `3.6.2`, `3.6.1`, `3.6.0`) - [Dockerfile](https://github.com/deegree/deegree3-docker/blob/main/3.6/Dockerfile)
+- deegree 3.6 (JDK 17/Tomcat 10.1): `3.6.7`, `3.6`, `latest` (deprecated tags: `3.6.6`, `3.6.5`, `3.6.4`, `3.6.3`, `3.6.2`, `3.6.1`, `3.6.0`) - [Dockerfile](https://github.com/deegree/deegree3-docker/blob/main/3.6/Dockerfile)
 - deegree 3.5 (JDK 11/Tomcat 9): `3.5.17`, `3.5` (deprecated tags: `3.5.16`, `3.5.15`, `3.5.14`, `3.5.13`, `3.5.12`, `3.5.11`, `3.5.10`, `3.5.8`, `3.5.7`, `3.5.6`, `3.5.5`, `3.5.4`, `3.5.3`, `3.5.2`, `3.5.1`, `3.5.0`) - [Dockerfile](https://github.com/deegree/deegree3-docker/blob/main/3.5/Dockerfile)
 - deegree 3.4 (JDK 8/Tomcat 8.5): `v3.4.35`, `v3.4`, `3.4` (deprecated tags: `v3.4.34`, `v3.4.33`, `v3.4.32`, `v3.4.31`, `v3.4.29`, `v3.4.28`, `v3.4.26`, `v3.4.25`, `v3.4.24`, `v3.4.23`, `v3.4.22`, `v3.4.20`, `v3.4.19`, `v3.4.18`, `v3.4.17`, `v3.4.16`, `v3.4.15`, `v3.4.14`, `v3.4.13`, `v3.4.12`, `v3.4.10`, `v3.4.9`, `v3.4.8`, `v3.4.7`, `v3.4.6`, `v3.4.5`, `v3.4.4`, `v3.4.3`, `v3.4.2`, `v3.4.1`, `v3.4.0`) - [Dockerfile](https://github.com/deegree/deegree3-docker/blob/main/3.4/Dockerfile)
 


### PR DESCRIPTION
This PR updates the latest deegree webservices Docker Image to bugfix version 3.6.7.